### PR TITLE
Add additional metadata and preferred language support for rplaylive

### DIFF
--- a/README.md
+++ b/README.md
@@ -1867,6 +1867,7 @@ The following extractors use this feature:
 #### rplaylive
 
 * `jwt_token`: JWT token that can be found as value of `_AUTHORIZATION_` entry from the browser local storage. This can be used as an alternative login method.
+* `lang`: Prefer translated metadata (`title`, `description`, and `uploader`) of this language code (case-sensitive) _if_ it exists for the video. 2 letter lowercase codes i.e. `en`, `jp`, `ko`
 
 **Note**: These options may be changed/removed in the future without concern for backward compatibility
 

--- a/README.md
+++ b/README.md
@@ -1867,7 +1867,7 @@ The following extractors use this feature:
 #### rplaylive
 
 * `jwt_token`: JWT token that can be found as value of `_AUTHORIZATION_` entry from the browser local storage. This can be used as an alternative login method.
-* `lang`: Prefer translated metadata (`title`, `description`, and `uploader`) of this language code (case-sensitive) _if_ it exists for the video. 2 letter lowercase codes i.e. `en`, `jp`, `ko`
+* `lang`: Provide language code (`en`, `jp`, `ko`) to use translated metadata (`title`, `description`, and `uploader`) when possible
 
 **Note**: These options may be changed/removed in the future without concern for backward compatibility
 

--- a/yt_dlp/extractor/rplaylive.py
+++ b/yt_dlp/extractor/rplaylive.py
@@ -215,6 +215,9 @@ class RPlayVideoIE(RPlayBaseIE):
             'uploader_id': ('creatorOid', {str}),
             'tags': ('hashtags', lambda _, v: v[0] != '_'),
             'age_limit': (('hideContent', 'isAdultContent'), {lambda x: 18 if x else None}, any),
+            'location': ('location', {str}),
+            'view_count': ('views', {int}),
+            'like_count': ('likes', {int}),
             'live_status': ('isReplayContent', {lambda x: 'was_live' if x else None}),
         })
         if self._preferred_lang:


### PR DESCRIPTION
Updates the rplaylive implementation to add optional preferred language support since the rplaylive api can send back optional translated metadata for the title, description, and uploader of a video in various languages.

This option is exposed with extractor options similar to the interface for the youtube extractor

Additionally, adds a few additional pieces of metadata to the video that are available in the API

Tested manually and updated tests/added a new test which function and pass with `hatch test RPlayVideoIE_all`